### PR TITLE
Fix empty menu item artifact when rendering the menu helper

### DIFF
--- a/blog/module/Application/src/View/Helper/Menu.php
+++ b/blog/module/Application/src/View/Helper/Menu.php
@@ -105,6 +105,7 @@ class Menu extends AbstractHelper
             $result .= '<li class="dropdown ' . ($isActive?'active':'') . '">';
             $result .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown">';
             $result .= $escapeHtml($label) . ' <b class="caret"></b>';
+            $result .= '</a>';
            
             $result .= '<ul class="dropdown-menu">';
             foreach ($dropdownItems as $item) {
@@ -116,7 +117,6 @@ class Menu extends AbstractHelper
                 $result .= '</li>';
             }
             $result .= '</ul>';
-            $result .= '</a>';
             $result .= '</li>';
             
         } else {        

--- a/formdemo/module/Application/src/View/Helper/Menu.php
+++ b/formdemo/module/Application/src/View/Helper/Menu.php
@@ -105,6 +105,7 @@ class Menu extends AbstractHelper
             $result .= '<li class="dropdown ' . ($isActive?'active':'') . '">';
             $result .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown">';
             $result .= $escapeHtml($label) . ' <b class="caret"></b>';
+            $result .= '</a>';
            
             $result .= '<ul class="dropdown-menu">';
             foreach ($dropdownItems as $item) {
@@ -116,7 +117,6 @@ class Menu extends AbstractHelper
                 $result .= '</li>';
             }
             $result .= '</ul>';
-            $result .= '</a>';
             $result .= '</li>';
             
         } else {        

--- a/helloworld/module/Application/src/View/Helper/Menu.php
+++ b/helloworld/module/Application/src/View/Helper/Menu.php
@@ -105,6 +105,7 @@ class Menu extends AbstractHelper
             $result .= '<li class="dropdown ' . ($isActive?'active':'') . '">';
             $result .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown">';
             $result .= $escapeHtml($label) . ' <b class="caret"></b>';
+            $result .= '</a>';
            
             $result .= '<ul class="dropdown-menu">';
             foreach ($dropdownItems as $item) {
@@ -116,7 +117,6 @@ class Menu extends AbstractHelper
                 $result .= '</li>';
             }
             $result .= '</ul>';
-            $result .= '</a>';
             $result .= '</li>';
             
         } else {        

--- a/userdemo/module/Application/src/View/Helper/Menu.php
+++ b/userdemo/module/Application/src/View/Helper/Menu.php
@@ -115,6 +115,7 @@ class Menu extends AbstractHelper
             $result .= '<li class="dropdown ' . ($isActive?'active':'') . '">';
             $result .= '<a href="#" class="dropdown-toggle" data-toggle="dropdown">';
             $result .= $escapeHtml($label) . ' <b class="caret"></b>';
+            $result .= '</a>';
            
             $result .= '<ul class="dropdown-menu">';
             foreach ($dropdownItems as $item) {
@@ -126,7 +127,6 @@ class Menu extends AbstractHelper
                 $result .= '</li>';
             }
             $result .= '</ul>';
-            $result .= '</a>';
             $result .= '</li>';
             
         } else {        


### PR DESCRIPTION
While using your Bootstrap menu helper from your samples I noticed that in the dropdown menus an empty menu item was introduced, before the real menu items. This was because the menu's "a.dropdown-toggle" was closed after the ul tag; the correct usage, instead, is to close it right before the ul tag, as it is done in the Bootstrap examples at http://getbootstrap.com/components/#navbar

Nice helper btw :-)