### PR TITLE
Possible fix for role inheritance

### DIFF
--- a/roledemo/module/User/src/Controller/RoleController.php
+++ b/roledemo/module/User/src/Controller/RoleController.php
@@ -63,7 +63,7 @@ class RoleController extends AbstractActionController
         foreach ($roles as $role) {
             $roleList[$role->getId()] = $role->getName();
         }
-        $form->get('inherit_roles[]')->setValueOptions($roleList);
+        $form->get('inherit_roles')->setValueOptions($roleList);
         
         // Check if user has submitted the form
         if ($this->getRequest()->isPost()) {
@@ -155,7 +155,7 @@ class RoleController extends AbstractActionController
         foreach ($roles as $role2) {
             $roleList[$role2->getId()] = $role2->getName();
         }
-        $form->get('inherit_roles[]')->setValueOptions($roleList);
+        $form->get('inherit_roles')->setValueOptions($roleList);
         
         // Check if user has submitted the form
         if ($this->getRequest()->isPost()) {

--- a/roledemo/module/User/src/Entity/Role.php
+++ b/roledemo/module/User/src/Entity/Role.php
@@ -132,6 +132,39 @@ class Role
     {
         return $this->permissions;
     }
+
+    public function addParent(Role $role)
+    {
+        if ($this->getId() == $role->getId()) {
+            return false;
+        }
+        if (!$this->hasParent($role)) {
+            $this->parentRoles[] = $role;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Clear parent roles
+     */
+    public function clearParentRoles()
+    {
+        $this->parentRoles = new ArrayCollection();
+    }
+
+    /**
+     * Check if parent role exists
+     * @param Role $role
+     * @return bool
+     */
+    public function hasParent(Role $role)
+    {
+        if ($this->getParentRoles()->contains($role)) {
+            return true;
+        }
+        return false;
+    }
 }
 
 

--- a/roledemo/module/User/src/Form/RoleForm.php
+++ b/roledemo/module/User/src/Form/RoleForm.php
@@ -67,9 +67,9 @@ class RoleForm extends Form
         // Add "inherit_roles" field
         $this->add([            
             'type'  => 'select',
-            'name' => 'inherit_roles[]',
+            'name' => 'inherit_roles',
             'attributes' => [
-                'id' => 'inherit_roles[]',
+                'id' => 'inherit_roles',
                 'multiple' => 'multiple',
             ],
             'options' => [
@@ -153,7 +153,7 @@ class RoleForm extends Form
         
         // Add input for "inherit_roles" field
         $inputFilter->add([
-                'name'     => 'inherit_roles[]',
+                'name'     => 'inherit_roles',
                 'required' => false,
                 'filters'  => [
                                     

--- a/roledemo/module/User/src/Form/UserForm.php
+++ b/roledemo/module/User/src/Form/UserForm.php
@@ -120,6 +120,17 @@ class UserForm extends Form
                 'label' => 'Role(s)',
             ],
         ]);
+
+        // Add the CSRF field
+        $this->add([
+            'type' => 'csrf',
+            'name' => 'csrf',
+            'options' => [
+                'csrf_options' => [
+                    'timeout' => 600
+                ]
+            ],
+        ]);
         
         // Add the Submit button
         $this->add([

--- a/roledemo/module/User/src/Service/RbacManager.php
+++ b/roledemo/module/User/src/Service/RbacManager.php
@@ -139,10 +139,19 @@ class RbacManager
                 
                 if ($params==null)
                     return true;
-                
+
                 foreach ($this->assertionManagers as $assertionManager) {
                     if ($assertionManager->assert($this->rbac, $permission, $params))
                         return true;
+                }
+            }
+
+            // Since we are pulling the user from the database again the init() function above is overridden?
+            // we don't seem to be taking into account the parent roles without the following code
+            $parentRoles = $role->getParentRoles();
+            foreach ($parentRoles as $parentRole) {
+                if ($this->rbac->isGranted($parentRole->getName(), $permission)) {
+                    return true;
                 }
             }
         }

--- a/roledemo/module/User/view/user/role/add.phtml
+++ b/roledemo/module/User/view/user/role/add.phtml
@@ -19,7 +19,7 @@ $form->get('description')->setAttributes([
     'placeholder'=>'Enter description'
     ]);
 
-$form->get('inherit_roles[]')->setAttributes([
+$form->get('inherit_roles')->setAttributes([
     'class'=>'form-control', 
     ]);
 
@@ -51,9 +51,9 @@ $form->prepare();
         </div>
         
         <div class="form-group">
-            <?= $this->formLabel($form->get('inherit_roles[]')); ?>
-            <?= $this->formElement($form->get('inherit_roles[]')); ?>
-            <?= $this->formElementErrors($form->get('inherit_roles[]')); ?>                  
+            <?= $this->formLabel($form->get('inherit_roles')); ?>
+            <?= $this->formElement($form->get('inherit_roles')); ?>
+            <?= $this->formElementErrors($form->get('inherit_roles')); ?>
         </div>
         
         <?= $this->formElement($form->get('csrf')); ?>

--- a/roledemo/module/User/view/user/role/edit.phtml
+++ b/roledemo/module/User/view/user/role/edit.phtml
@@ -19,7 +19,7 @@ $form->get('description')->setAttributes([
     'placeholder'=>'Enter description'
     ]);
 
-$form->get('inherit_roles[]')->setAttributes([
+$form->get('inherit_roles')->setAttributes([
     'class'=>'form-control', 
     ]);
 
@@ -56,9 +56,9 @@ $form->prepare();
         </div>
         
         <div class="form-group">
-            <?= $this->formLabel($form->get('inherit_roles[]')); ?>
-            <?= $this->formElement($form->get('inherit_roles[]')); ?>
-            <?= $this->formElementErrors($form->get('inherit_roles[]')); ?>                  
+            <?= $this->formLabel($form->get('inherit_roles')); ?>
+            <?= $this->formElement($form->get('inherit_roles')); ?>
+            <?= $this->formElementErrors($form->get('inherit_roles')); ?>
         </div>
         
         <?= $this->formElement($form->get('csrf')); ?>

--- a/roledemo/module/User/view/user/user/add.phtml
+++ b/roledemo/module/User/view/user/user/add.phtml
@@ -87,7 +87,9 @@ $form->prepare();
             <?= $this->formElement($form->get('roles')); ?>
             <?= $this->formElementErrors($form->get('roles')); ?>                  
         </div>
-        
+
+        <?= $this->formElement($form->get('csrf')); ?>
+        <?= $this->formElementErrors($form->get('csrf')); ?>
         <?= $this->formElement($form->get('submit')); ?>
         
         <?= $this->form()->closeTag(); ?>

--- a/roledemo/module/User/view/user/user/edit.phtml
+++ b/roledemo/module/User/view/user/user/edit.phtml
@@ -63,7 +63,9 @@ $form->prepare();
             <?= $this->formElement($form->get('roles')); ?>
             <?= $this->formElementErrors($form->get('roles')); ?>                  
         </div>
-        
+
+        <?= $this->formElement($form->get('csrf')); ?>
+        <?= $this->formElementErrors($form->get('csrf')); ?>
         <?= $this->formElement($form->get('submit')); ?>
         
         <?= $this->form()->closeTag(); ?>


### PR DESCRIPTION
Added csrf component to UserForm, view/user/edit.phtml and view/user/add.phtml.
Fixes problems with role inheritance.

After these changes if you add a new role which is inherited from the Administrator role, the changes are now populated in the database and the view updates properly to show inherited roles. Creating a new user with the inherited role, allows to login with same permissions as inherited role.

Addresses issue #35 