### PR TITLE
[PR] fixed Vagrantfile for userdemo

### DIFF
--- a/userdemo/Vagrantfile
+++ b/userdemo/Vagrantfile
@@ -4,16 +4,40 @@
 VAGRANTFILE_API_VERSION = '2'
 
 @script = <<SCRIPT
+
+# PHP
 add-apt-repository ppa:ondrej/php
 apt-get update
-apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0
+apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0 php7.0-mcrypt php7.0-gd php7.0-mysql
+
+# APACHE
 sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf
 a2enmod rewrite
 service apache2 restart
+
+# DATABASE
+debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
+debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
+apt-get install -y mysql-server
+mysql -u root -proot -e "CREATE DATABASE userdemo;"
+mysql -u root -proot -e "GRANT ALL PRIVILEGES ON userdemo.* TO userdemo@localhost identified by '<password>';"
+cd /var/www/ && ./vendor/bin/doctrine-module migrations:migrate
+
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+cd /var/www/
+composer install
+
+sudo chown -R www-data:www-data data
+sudo chmod -R 775 data
+mkdir public/img/captcha
+sudo chown -R www-data:www-data public/img/captcha
+sudo chmod -R 775 public/img/captcha
+cp config/autoload/local.php.dist config/autoload/local.php
+
 if ! grep "cd /var/www" /home/vagrant/.profile > /dev/null; then
     echo "cd /var/www" >> /home/vagrant/.profile
 fi
+
 echo "** [ZF] Run the following command to install dependencies, if you have not already:"
 echo "    vagrant ssh -c 'composer install'"
 echo "** [ZF] Visit http://localhost:8080 in your browser for to view the application **"

--- a/userdemo/Vagrantfile
+++ b/userdemo/Vagrantfile
@@ -23,10 +23,13 @@ mysql -u root -proot -e "CREATE DATABASE userdemo;"
 mysql -u root -proot -e "GRANT ALL PRIVILEGES ON userdemo.* TO userdemo@localhost identified by '<password>';"
 cd /var/www/ && ./vendor/bin/doctrine-module migrations:migrate
 
+# COMPOSER
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 cd /var/www/
 composer install
+composer development-enable
 
+# OTHER
 sudo chown -R www-data:www-data data
 sudo chmod -R 775 data
 mkdir public/img/captcha

--- a/userdemo/Vagrantfile
+++ b/userdemo/Vagrantfile
@@ -11,7 +11,20 @@ apt-get update
 apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0 php7.0-mcrypt php7.0-gd php7.0-mysql
 
 # APACHE
-sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf
+echo "<VirtualHost *:80>
+	DocumentRoot \"/var/www/public\"
+	AllowEncodedSlashes On
+
+	ServerName "using-zf3-book-samples.userdemo.local.vm";
+	ServerAlias "www.using-zf3-book-samples.userdemo.local.vm";
+
+	<Directory \"/var/www/public\">
+		DirectoryIndex index.php
+        AllowOverride All
+        Require all granted
+	</Directory>
+
+</VirtualHost>" > /etc/apache2/sites-available/000-default.conf
 a2enmod rewrite
 service apache2 restart
 


### PR DESCRIPTION
Replicated Installation Steps from README.md
Changes in ./userdemo/Vagrantfile
- Vagrant installs missing PHP extensions - GB and Mcrypt
- Installs Mysql with `userdemo` DB and user. the password is `<password>`
- composer install
- change permissions for `./data` and `./public/img/captcha`
- turn o the development mode